### PR TITLE
use the clustercomp submission site

### DIFF
--- a/2019/student/index.html
+++ b/2019/student/index.html
@@ -483,7 +483,7 @@ apply.</p>
 <h2 id="submission-guidelines">Submission Guidelines</h2>
 <p>Please submit your application via <strong>TBD</strong>
 
-<!-- <a href="https://ssl.linklings.net/conferences/ieeecluster/?page=Submit&amp;id=StudentApplication&amp;site=ieeecluster2018">submission system.</a></p>
+<!-- <a href="https://clustercomp.org/submit?page=Submit&amp;id=StudentApplication&amp;site=ieeecluster2018">submission system.</a></p>
 -->
 <h2 id="important-dates">Important Dates</h2>
 <p>Applications will be reviewed starting at a date <strong>TBD</strong>.</p>

--- a/2019/technical/index.html
+++ b/2019/technical/index.html
@@ -552,7 +552,7 @@ the following Xplore layout, page limit, and font size.
 <li>LaTeX and Word Templates are available 
     <a href="http://www.ieee.org/conferences_events/conferences/publishing/templates.html">here</a></li>
 <li>Only web-based submissions are allowed.</li>
-<li>Please submit your paper via the <a href="https://ssl.linklings.net/conferences/ieeecluster/">
+<li>Please submit your paper via the <a href="https://clustercomp.org/submit">
     online submission system</a></li>
 </ul>
 

--- a/2019/workshops/index.html
+++ b/2019/workshops/index.html
@@ -481,7 +481,7 @@
       organizer (two pages maximum per organizer).</p>
 
       <p>A single PDF file with all the material described above should be submitted to the Cluster 2019 
-      conference <a href="https://ssl.linklings.net/conferences/ieeecluster/">online submission system</a>
+      conference <a href="https://clustercomp.org/submit">online submission system</a>
       under the workshop track.  Acceptance of a proposed workshop will be made based on the quality, content 
       and organization, and its relationship to key topic areas when compared with other submissions.</p>
 


### PR DESCRIPTION
Use the https://clustercomp.org/submit site for submissions (to
maintain consistency over years) instead of the linklings site
directly.  The former will automatically redirect to the latter and is
what is sent to the authors with the linklings notifications.