### PR TITLE
Revert "Added a link to the steering committee"

### DIFF
--- a/2019/committees/index.html
+++ b/2019/committees/index.html
@@ -520,9 +520,6 @@ Martin Schulz, Technische Universität München</p>
 <p><strong>Chair:</strong> David Boehme, Lawrence Livermore National Laboratories</p>
 <p></p>
 
-<h2 id="steering-committee"><a href="https://clustercomp.org/committee/Committees.html">Steering Committee</a></h2>
-<p></p>
-
 			</span>
 
 			


### PR DESCRIPTION
Reverts ieeecluster/ieeecluster.github.io#2

I am sorry. I accidentally merged this PR.